### PR TITLE
Consolidating SMT solvers and adding solver-agnostic api repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: c
 dist: trusty
 
-cache: apt
+cache:
+  apt: true
+  directories:
+    # cache smt solvers to speed up build
+    ./smt_solvers
 
 compiler:
   - gcc
@@ -38,6 +42,10 @@ before_install:
 
   - git clone https://github.com/cdonovick/smt-pnr
 
+  # API for SMT solving with different solvers
+  - git clone https://github.com/makaimann/smt-switch
+  - export PYTHONPATH=$PYTHONPATH:$PWD/smt-switch
+
 install:
   -  pwd
   
@@ -45,18 +53,10 @@ install:
   - ${TRAVIS_BUILD_DIR}/Halide_CoreIR/test/scripts/install_travis.sh
 
   # pnr
-    # Install monosat from Makai's binary (ping him to rebuild it if newer features are needed)
-  - wget http://web.stanford.edu/~makaim/files/monosat_bin.tar.gz
-  - tar -xvf monosat_bin.tar.gz
-  - export PATH=$PATH:$PWD/monosat_bin
-  - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/monosat_bin
-  - pip install -e monosat_bin/python
-    # Install z3 from release binary
-  - wget https://github.com/Z3Prover/z3/releases/download/z3-4.5.0/z3-4.5.0-x64-ubuntu-14.04.zip
-  - unzip z3-4.5.0-x64-ubuntu-14.04.zip
-  - export PATH=$PATH:$PWD/z3-4.5.0-x64-ubuntu-14.04/bin/
-  - export PYTHONPATH=$PYTHONPATH:$PWD/z3-4.5.0-x64-ubuntu-14.04/bin/python/
-  - sudo ln -s $PWD/z3-4.5.0-x64-ubuntu-14.04/bin/libz3.so /usr/lib/libz3.so
+  # run script that installs solvers and adds necessary environment variables
+  # if all the solvers are already cached it doesn't need to download
+  # if there are any missing solvers, downloads from Makai's AFS
+  - . ./smt-pnr/util/get_smt_solvers.sh
   - pip install pygraphviz
   - pip install lxml
 
@@ -225,6 +225,8 @@ addons:
       - zlib1g-dev
       - graphviz-dev
       - python3
+      - swig2.0
+      - libcln-dev
 
       # convert png to raw
       - imagemagick


### PR DESCRIPTION
All SMT solvers are now bundled in the folder smt_solvers.
Currently includes z3, cvc4 and monosat.

The script smt-pnr/util/get_smt_solvers.sh checks if the folder is present
and that it contains all solvers and if its missing any, the script
downloads the whole tarball from
http://web.stanford.edu/~makaim/files/smt_solvers.tar.gz

Then it adds solver directories to the necessary paths.

The folder is cached to speed up the build on subsequent runs.

=================== Why the changes ==============================

These changes are part of incorporating a solver agnostic API that
I've been working on into pnr. This allows us to change the underlying
smt solvers. Currently supports z3 and cvc4.

The API is similar to pySMT but follows SMT-LIB more closely.
Additionally, it will allow us to incorporate optimization or
new theories for multiple solvers in the future.

Using the script to get the smt solvers makes it so we don't have to
change the .travis.yml of the flow every time we add a new smt solver.

Let me know if there are any comments/concerns!