### PR TITLE
Srcleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -207,6 +207,7 @@ script:
   # - cp ${EXAMPLE3}/PNRguys_io.xml     ${TRAVIS_BUILD_DIR}/build/io.xml;
   ##############################################################################
 
+
 #   # cgra program and run (ankita)
 #   # IN:  config.dat    (Bitstream for programming CGRA)
 #   #      io.xml        (I/O pin information for CGRA)

--- a/.travis.yml
+++ b/.travis.yml
@@ -132,11 +132,17 @@ script:
   #      pnr_bitstream    # bitstream file
   #
   - cd ${TRAVIS_BUILD_DIR}/smt-pnr/src/
-  - ./test.py 
+
+  - ./test.py --help
+
+  - ./test.py --print
     ../../build/mapped.json
     ../../CGRAGenerator/hardware/generator_z/top/cgra_info.txt 
     --xml ../../build/mapped.xml ../../build/io.xml
     --bitstream ../../pnr_bitstream
+
+
+
 
   - ls -l ../../pnr_bitstream ../../build/mapped.xml
   - cat ../../build/mapped.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -207,7 +207,7 @@ script:
   # - cp ${EXAMPLE3}/PNRguys_io.xml     ${TRAVIS_BUILD_DIR}/build/io.xml;
   ##############################################################################
 
-  # cgra program and run
+  # cgra program and run (ankita)
   # IN:  config.dat    (Bitstream for programming CGRA)
   #      io.xml        (I/O pin information for CGRA)
   #      input.png     (Input image)
@@ -222,11 +222,16 @@ script:
         -output ${TRAVIS_BUILD_DIR}/build/CGRA_out.raw
         -nclocks 5M
 
-
   # Try again using caleb bitstream?
+  # cgra program and run (caleb)
+  # IN:  pnr_bitstream (Bitstream for programming CGRA)
+  #      input.png     (Input image)
+  # OUT: CGRA_out.raw  (Output image)
+  #
+  - echo "CGRA program and run (uses output of pnr)" - `date`
+  - cd ${TRAVIS_BUILD_DIR}/CGRAGenerator/verilator/generator_z_tb
   - ./run.csh top_tb.cpp
         -config ${TRAVIS_BUILD_DIR}/pnr_bitstream
-        -io     ${TRAVIS_BUILD_DIR}/build/io.xml
         -input  ${TRAVIS_BUILD_DIR}/build/input.png
         -output ${TRAVIS_BUILD_DIR}/build/CGRA_out.raw
         -nclocks 5M

--- a/.travis.yml
+++ b/.travis.yml
@@ -123,7 +123,7 @@ script:
   - echo "CGRA generate (generates CGRA + connection matrix for pnr)" - `date`
   - pushd ${TRAVIS_BUILD_DIR}/CGRAGenerator; ./travis-test.csh; popd
 
-  # pnr
+  # pnr place and route
   # IN:  mapped.json      # Output from mapper
   #      cgra_info.txt    # Fully-populated connection matrix from CGRA generator
   #
@@ -138,7 +138,8 @@ script:
     --xml ../../build/mapped.xml ../../build/io.xml
     --bitstream ../../pnr_bitstream
 
-
+  - ls -l ../../pnr_bitstream
+  - cat ../../pnr_bitstream
 
   # bitstream build
   # IN:  mapped.xml    (Sparse connection matrix map from PNR)
@@ -155,6 +156,11 @@ script:
        ${TRAVIS_BUILD_DIR}/build/mapped.xml
        ${TRAVIS_BUILD_DIR}/build/config
        || exit -1
+
+  - ls -l ${TRAVIS_BUILD_DIR}/build/config
+  - cat ${TRAVIS_BUILD_DIR}/build/config
+  - diff ${TRAVIS_BUILD_DIR}/build/config ../../pnr_bitstream
+
 
 
   ##############################################################################

--- a/.travis.yml
+++ b/.travis.yml
@@ -180,6 +180,8 @@ script:
     --xml ../../build/mapped.xml ../../build/io.xml
     --bitstream ../../pnr_bitstream
 
+  # FIXME note caleb's script puts output in ../../ instead of ../../build/
+
   # Look at Caleb's bitstream
   - ls -l ../../pnr_bitstream ../../build/mapped.xml
   - cat ../../build/mapped.xml
@@ -234,6 +236,15 @@ script:
   - cd ${TRAVIS_BUILD_DIR}/CGRAGenerator/verilator/generator_z_tb
   - ./run.csh top_tb.cpp
         -config ${TRAVIS_BUILD_DIR}/build/config.dat
+        -io     ${TRAVIS_BUILD_DIR}/build/io.xml
+        -input  ${TRAVIS_BUILD_DIR}/build/input.png
+        -output ${TRAVIS_BUILD_DIR}/build/CGRA_out.raw
+        -nclocks 5M
+
+
+  # Try again using caleb bitstream?
+  - ./run.csh top_tb.cpp
+        -config ${TRAVIS_BUILD_DIR}/pnr_bitstream
         -io     ${TRAVIS_BUILD_DIR}/build/io.xml
         -input  ${TRAVIS_BUILD_DIR}/build/input.png
         -output ${TRAVIS_BUILD_DIR}/build/CGRA_out.raw

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,8 +50,6 @@ before_install:
   - export PYTHONPATH=${BS}/decoder/:${PYTHONPATH}
   - ${BS}/decoder/decode.py ${BS}/example3/PNRguys_config.dat
 
-  # DIE!
-  - grep foo bar
 
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -237,5 +237,3 @@ addons:
 env:
   # halide
   - LLVM_VERSION=3.7.1 BUILD_SYSTEM=MAKE CXX_=g++-4.9 CC_=gcc-4.9
-
-# SR: forcing a build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: c
 dist: trusty
 
-cache: apt
+cache:
+  apt: true
+  directories:
+    # cache smt solvers to speed up build
+    ./smt_solvers
 
 compiler:
   - gcc
@@ -38,6 +42,10 @@ before_install:
 
   - git clone https://github.com/cdonovick/smt-pnr
 
+  # API for SMT solving with different solvers
+  - git clone https://github.com/makaimann/smt-switch
+  - export PYTHONPATH=$PYTHONPATH:$PWD/smt-switch
+
 install:
   -  pwd
   
@@ -45,18 +53,10 @@ install:
   - ${TRAVIS_BUILD_DIR}/Halide_CoreIR/test/scripts/install_travis.sh
 
   # pnr
-    # Install monosat from Makai's binary (ping him to rebuild it if newer features are needed)
-  - wget http://web.stanford.edu/~makaim/files/monosat_bin.tar.gz
-  - tar -xvf monosat_bin.tar.gz
-  - export PATH=$PATH:$PWD/monosat_bin
-  - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/monosat_bin
-  - pip install -e monosat_bin/python
-    # Install z3 from release binary
-  - wget https://github.com/Z3Prover/z3/releases/download/z3-4.5.0/z3-4.5.0-x64-ubuntu-14.04.zip
-  - unzip z3-4.5.0-x64-ubuntu-14.04.zip
-  - export PATH=$PATH:$PWD/z3-4.5.0-x64-ubuntu-14.04/bin/
-  - export PYTHONPATH=$PYTHONPATH:$PWD/z3-4.5.0-x64-ubuntu-14.04/bin/python/
-  - sudo ln -s $PWD/z3-4.5.0-x64-ubuntu-14.04/bin/libz3.so /usr/lib/libz3.so
+  # run script that installs solvers and adds necessary environment variables
+  # if all the solvers are already cached it doesn't need to download
+  # if there are any missing solvers, downloads from Makai's AFS
+  - . ./smt-pnr/util/get_smt_solvers.sh
   - pip install pygraphviz
   - pip install lxml
 
@@ -123,7 +123,7 @@ script:
   - echo "CGRA generate (generates CGRA + connection matrix for pnr)" - `date`
   - pushd ${TRAVIS_BUILD_DIR}/CGRAGenerator; ./travis-test.csh; popd
 
-  # pnr place and route
+  # pnr
   # IN:  mapped.json      # Output from mapper
   #      cgra_info.txt    # Fully-populated connection matrix from CGRA generator
   #
@@ -132,22 +132,13 @@ script:
   #      pnr_bitstream    # bitstream file
   #
   - cd ${TRAVIS_BUILD_DIR}/smt-pnr/src/
-
-  - pip install smt_switch
-  - ./test.py --help
-
-  - ./test.py --print
+  - ./test.py 
     ../../build/mapped.json
     ../../CGRAGenerator/hardware/generator_z/top/cgra_info.txt 
     --xml ../../build/mapped.xml ../../build/io.xml
     --bitstream ../../pnr_bitstream
 
 
-
-
-  - ls -l ../../pnr_bitstream ../../build/mapped.xml
-  - cat ../../build/mapped.xml
-  - cat ../../pnr_bitstream
 
   # bitstream build
   # IN:  mapped.xml    (Sparse connection matrix map from PNR)
@@ -158,16 +149,12 @@ script:
   #
   - echo "Build bitstream for programming CGRA" - `date`
   - EXAMPLE3=${TRAVIS_BUILD_DIR}/CGRAGenerator/bitstream/example3
-  - ls -l ${TRAVIS_BUILD_DIR}/build/mapped.xml
+  - ls -l ${EXAMPLE3}/gen_bitstream.pl
+       ${TRAVIS_BUILD_DIR}/build/mapped.xml
   - perl ${EXAMPLE3}/gen_bitstream.pl
        ${TRAVIS_BUILD_DIR}/build/mapped.xml
        ${TRAVIS_BUILD_DIR}/build/config
        || exit -1
-
-  - ls -l ${TRAVIS_BUILD_DIR}/build/config.dat
-  - cat ${TRAVIS_BUILD_DIR}/build/config.dat
-  - diff ${TRAVIS_BUILD_DIR}/build/config.dat ../../pnr_bitstream
-
 
 
   ##############################################################################
@@ -238,6 +225,8 @@ addons:
       - zlib1g-dev
       - graphviz-dev
       - python3
+      - swig2.0
+      - libcln-dev
 
       # convert png to raw
       - imagemagick

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,28 @@
 language: c
 dist: trusty
 
+env:
+  global:
+    - halide_git="https://github.com/jeffsetter/Halide_CoreIR.git"
+    - coreir_git="https://github.com/rdaly525/coreir.git"
+    - mapper_git="https://github.com/StanfordAHA/CGRAMapper.git"
+    - cgra_git="https://github.com/StanfordAHA/CGRAGenerator.git"
+    - pnr_git="https://github.com/cdonovick/smt-pnr"
+    - smt_git="https://github.com/makaimann/smt-switch" 
+
+    - halide_branch="coreir"
+    - coreir_branch="master"
+    - mapper_branch="master"
+    - cgra_branch="master"
+    - pnr_branch="master"
+    - smt_branch="master"
+
+    #halide
+    - LLVM_VERSION=3.7.1
+    - BUILD_SYSTEM=MAKE
+    - CXX_=g++-4.9 
+    - CC_=gcc-4.9
+
 cache:
   apt: true
   directories:
@@ -15,11 +37,18 @@ before_install:
   - virtualenv -p /usr/bin/python3 CGRAFlowPy3Env
   - source CGRAFlowPy3Env/bin/activate
 
-  - # pull our modified halide repo and setup halide env vars
-  - git clone https://github.com/jeffsetter/Halide_CoreIR.git
+  #pull all repos
+  - git clone -b ${halide_branch} -- ${halide_git}
+  - git clone -b ${coreir_branch} -- ${coreir_git}
+  - git clone -b ${mapper_branch} -- ${mapper_git}
+  - git clone -b ${cgra_branch} -- ${cgra_git}
+  - git clone -b ${pnr_branch} -- ${pnr_git}
+  - git clone -b ${smt_branch} -- ${smt_git}
+
+  # setup halide env vars
   - source Halide_CoreIR/test/scripts/before_install_travis.sh
 
-  - git clone https://github.com/rdaly525/coreir.git;
+  # build coreir
   - cd coreir;
   - export COREIRCONFIG="g++-4.9";
   - export COREIRHOME=$PWD
@@ -32,18 +61,13 @@ before_install:
   # I think the script might be lost...here's a quick reset.
   - cd ${TRAVIS_BUILD_DIR};
 
-  - git clone https://github.com/StanfordAHA/CGRAMapper.git;
   - cd CGRAMapper/mapper;
   -   make;
   - cd ../../;
 
   - date
-  - git clone https://github.com/StanfordAHA/CGRAGenerator.git
-
-  - git clone https://github.com/cdonovick/smt-pnr
 
   # API for SMT solving with different solvers
-  - git clone https://github.com/makaimann/smt-switch
   - export PYTHONPATH=$PYTHONPATH:$PWD/smt-switch
 
 install:
@@ -131,29 +155,12 @@ script:
   #      io.xml           # I/O pin information for CGRA
   #      pnr_bitstream    # bitstream file
   #
-#   - cd ${TRAVIS_BUILD_DIR}/smt-pnr/src/
-#   - ./test.py 
-#     ../../build/mapped.json
-#     ../../CGRAGenerator/hardware/generator_z/top/cgra_info.txt 
-#     --xml ../../build/mapped.xml ../../build/io.xml
-#     --bitstream ../../pnr_bitstream
-
   - cd ${TRAVIS_BUILD_DIR}/smt-pnr/src/
-
-  - ./test.py --help
-
-  - ./test.py --print
+  - ./test.py 
     ../../build/mapped.json
     ../../CGRAGenerator/hardware/generator_z/top/cgra_info.txt 
     --xml ../../build/mapped.xml ../../build/io.xml
     --bitstream ../../pnr_bitstream
-
-
-
-
-  - ls -l ../../pnr_bitstream ../../build/mapped.xml
-  - cat ../../build/mapped.xml
-  - cat ../../pnr_bitstream
 
 
 
@@ -247,6 +254,3 @@ addons:
 
       # convert png to raw
       - imagemagick
-env:
-  # halide
-  - LLVM_VERSION=3.7.1 BUILD_SYSTEM=MAKE CXX_=g++-4.9 CC_=gcc-4.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,24 @@ before_install:
   - virtualenv -p /usr/bin/python3 CGRAFlowPy3Env
   - source CGRAFlowPy3Env/bin/activate
 
+
+
+
+
+  # Debugging the decoder
+  - git clone -b ${cgra_branch} -- ${cgra_git}
+  - BS=${TRAVIS_BUILD_DIR}/CGRAGenerator/bitstream
+  - ls -l ${BS}/decoder/lib
+  - export PYTHONPATH=${BS}/decoder/:${PYTHONPATH}
+  - ${BS}/decoder/decode.py ${BS}/example3/PNRguys_config.dat
+
+  # DIE!
+  - grep foo bar
+
+
+
+
+
   #pull all repos
   - git clone -b ${halide_branch} -- ${halide_git}
   - git clone -b ${coreir_branch} -- ${coreir_git}

--- a/.travis.yml
+++ b/.travis.yml
@@ -169,6 +169,7 @@ script:
 
   # Decode Caleb's bitstream
   - BS=${TRAVIS_BUILD_DIR}/CGRAGenerator/bitstream
+  - export PYTHONPATH=${BS}/decoder/:${PYTHONPATH}
   - ${BS}/decoder/decode.py ../../pnr_bitstream
 
 
@@ -192,6 +193,7 @@ script:
 
   # Decode Ankita's bitstream
   - BS=${TRAVIS_BUILD_DIR}/CGRAGenerator/bitstream
+  - export PYTHONPATH=${BS}/decoder/:${PYTHONPATH}
   - ${BS}/decoder/decode.py ${TRAVIS_BUILD_DIR}/build/config.dat
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,8 @@ before_install:
   # Debugging the decoder
   - git clone -b ${cgra_branch} -- ${cgra_git}
   - BS=${TRAVIS_BUILD_DIR}/CGRAGenerator/bitstream
+  - ls -l ${BS}
+  - ls -l ${BS}/decoder
   - ls -l ${BS}/decoder/lib
   - export PYTHONPATH=${BS}/decoder/:${PYTHONPATH}
   - ${BS}/decoder/decode.py ${BS}/example3/PNRguys_config.dat

--- a/.travis.yml
+++ b/.travis.yml
@@ -131,12 +131,29 @@ script:
   #      io.xml           # I/O pin information for CGRA
   #      pnr_bitstream    # bitstream file
   #
+#   - cd ${TRAVIS_BUILD_DIR}/smt-pnr/src/
+#   - ./test.py 
+#     ../../build/mapped.json
+#     ../../CGRAGenerator/hardware/generator_z/top/cgra_info.txt 
+#     --xml ../../build/mapped.xml ../../build/io.xml
+#     --bitstream ../../pnr_bitstream
+
   - cd ${TRAVIS_BUILD_DIR}/smt-pnr/src/
-  - ./test.py 
+
+  - ./test.py --help
+
+  - ./test.py --print
     ../../build/mapped.json
     ../../CGRAGenerator/hardware/generator_z/top/cgra_info.txt 
     --xml ../../build/mapped.xml ../../build/io.xml
     --bitstream ../../pnr_bitstream
+
+
+
+
+  - ls -l ../../pnr_bitstream ../../build/mapped.xml
+  - cat ../../build/mapped.xml
+  - cat ../../pnr_bitstream
 
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -169,6 +169,7 @@ script:
 
   # Decode Caleb's bitstream
   - BS=${TRAVIS_BUILD_DIR}/CGRAGenerator/bitstream
+  - ls -l ${BS}/decoder/lib
   - export PYTHONPATH=${BS}/decoder/:${PYTHONPATH}
   - ${BS}/decoder/decode.py ../../pnr_bitstream
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -157,9 +157,9 @@ script:
        ${TRAVIS_BUILD_DIR}/build/config
        || exit -1
 
-  - ls -l ${TRAVIS_BUILD_DIR}/build/config
-  - cat ${TRAVIS_BUILD_DIR}/build/config
-  - diff ${TRAVIS_BUILD_DIR}/build/config ../../pnr_bitstream
+  - ls -l ${TRAVIS_BUILD_DIR}/build/config.dat
+  - cat ${TRAVIS_BUILD_DIR}/build/config.dat
+  - diff ${TRAVIS_BUILD_DIR}/build/config.dat ../../pnr_bitstream
 
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -168,13 +168,13 @@ script:
   - cat ../../pnr_bitstream
 
   # Decode Caleb's bitstream
-  - BS=${TRAVIS_BUILD_DIR}/CGRAGenerator/
+  - BS=${TRAVIS_BUILD_DIR}/CGRAGenerator/bitstream
   - ${BS}/decoder/decode.py ../../pnr_bitstream
 
 
   # Build Ankita bitstream for comparison
 
-  # bitstream build
+  # bitstream build (ankita perl script)
   # IN:  mapped.xml    (Sparse connection matrix map from PNR)
   # OUT: config.dat    (Bitstream for programming CGRA)
   # 
@@ -182,16 +182,16 @@ script:
   # FIXME don't worry soon it will be replaced by Caleb's script
   #
   - echo "Build bitstream for programming CGRA" - `date`
-  - EXAMPLE3=${TRAVIS_BUILD_DIR}/CGRAGenerator/bitstream/example3
-  - ls -l ${EXAMPLE3}/gen_bitstream.pl
+  - GENBS=${TRAVIS_BUILD_DIR}/CGRAGenerator/bitstream/example3/
+  - ls -l ${GENBS}/gen_bitstream.pl
        ${TRAVIS_BUILD_DIR}/build/mapped.xml
-  - perl ${EXAMPLE3}/gen_bitstream.pl
+  - perl ${GENBS}/gen_bitstream.pl
        ${TRAVIS_BUILD_DIR}/build/mapped.xml
        ${TRAVIS_BUILD_DIR}/build/config
        || exit -1
 
   # Decode Ankita's bitstream
-  - BS=${TRAVIS_BUILD_DIR}/CGRAGenerator/
+  - BS=${TRAVIS_BUILD_DIR}/CGRAGenerator/bitstream
   - ${BS}/decoder/decode.py ${TRAVIS_BUILD_DIR}/build/config.dat
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -163,42 +163,6 @@ script:
     --bitstream ../../pnr_bitstream
 
 #   # FIXME note caleb's script puts output in ../../ instead of ../../build/ (above)
-# 
-#   # Look at Caleb's bitstream
-#   - ls -l ../../pnr_bitstream ../../build/mapped.xml
-#   - cat ../../build/mapped.xml
-#   - cat ../../pnr_bitstream
-# 
-#   # Decode Caleb's bitstream
-#   - BS=${TRAVIS_BUILD_DIR}/CGRAGenerator/bitstream
-#   - ls -l ${BS}/decoder/lib
-#   - export PYTHONPATH=${BS}/decoder/:${PYTHONPATH}
-#   - ${BS}/decoder/decode.py ../../pnr_bitstream
-# 
-# 
-#   # Build Ankita bitstream for comparison
-# 
-#   # bitstream build (ankita perl script)
-#   # IN:  mapped.xml    (Sparse connection matrix map from PNR)
-#   # OUT: config.dat    (Bitstream for programming CGRA)
-#   # 
-#   # FIXME this is a terrible place for the perl script to live
-#   # FIXME don't worry soon it will be replaced by Caleb's script
-#   #
-#   - echo "Build bitstream for programming CGRA" - `date`
-#   - GENBS=${TRAVIS_BUILD_DIR}/CGRAGenerator/bitstream/example3/
-#   - ls -l ${GENBS}/gen_bitstream.pl
-#        ${TRAVIS_BUILD_DIR}/build/mapped.xml
-#   - perl ${GENBS}/gen_bitstream.pl
-#        ${TRAVIS_BUILD_DIR}/build/mapped.xml
-#        ${TRAVIS_BUILD_DIR}/build/config
-#        || exit -1
-# 
-#   # Decode Ankita's bitstream
-#   - BS=${TRAVIS_BUILD_DIR}/CGRAGenerator/bitstream
-#   - export PYTHONPATH=${BS}/decoder/:${PYTHONPATH}
-#   - ${BS}/decoder/decode.py ${TRAVIS_BUILD_DIR}/build/config.dat
-
 
   ##############################################################################
   # Little temporary hack to get around instabilities above when/if needed.
@@ -207,24 +171,8 @@ script:
   # - cp ${EXAMPLE3}/PNRguys_io.xml     ${TRAVIS_BUILD_DIR}/build/io.xml;
   ##############################################################################
 
-
-#   # cgra program and run (ankita)
-#   # IN:  config.dat    (Bitstream for programming CGRA)
-#   #      io.xml        (I/O pin information for CGRA)
-#   #      input.png     (Input image)
-#   # OUT: CGRA_out.raw  (Output image)
-#   #
-#   - echo "CGRA program and run (uses output of pnr)" - `date`
-#   - cd ${TRAVIS_BUILD_DIR}/CGRAGenerator/verilator/generator_z_tb
-#   - ./run.csh top_tb.cpp
-#         -config ${TRAVIS_BUILD_DIR}/build/config.dat
-#         -io     ${TRAVIS_BUILD_DIR}/build/io.xml
-#         -input  ${TRAVIS_BUILD_DIR}/build/input.png
-#         -output ${TRAVIS_BUILD_DIR}/build/CGRA_out.raw
-#         -nclocks 5M
-
   # Try again using caleb bitstream?
-  # cgra program and run (caleb)
+  # cgra program and run (caleb bitstream)
   # IN:  pnr_bitstream (Bitstream for programming CGRA)
   #      input.png     (Input image)
   # OUT: CGRA_out.raw  (Output image)

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,24 +37,6 @@ before_install:
   - virtualenv -p /usr/bin/python3 CGRAFlowPy3Env
   - source CGRAFlowPy3Env/bin/activate
 
-
-
-
-
-#   # Debugging the decoder
-#   - git clone -b ${cgra_branch} -- ${cgra_git}
-#   - BS=${TRAVIS_BUILD_DIR}/CGRAGenerator/bitstream
-#   - ls -l ${BS}
-#   - ls -l ${BS}/decoder
-#   - ls -l ${BS}/decoder/lib
-#   - export PYTHONPATH=${BS}/decoder/:${PYTHONPATH}
-#   - ${BS}/decoder/decode.py ${BS}/example3/PNRguys_config.dat
-# 
-
-
-
-
-
   #pull all repos
   - git clone -b ${halide_branch} -- ${halide_git}
   - git clone -b ${coreir_branch} -- ${coreir_git}

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,15 +41,15 @@ before_install:
 
 
 
-  # Debugging the decoder
-  - git clone -b ${cgra_branch} -- ${cgra_git}
-  - BS=${TRAVIS_BUILD_DIR}/CGRAGenerator/bitstream
-  - ls -l ${BS}
-  - ls -l ${BS}/decoder
-  - ls -l ${BS}/decoder/lib
-  - export PYTHONPATH=${BS}/decoder/:${PYTHONPATH}
-  - ${BS}/decoder/decode.py ${BS}/example3/PNRguys_config.dat
-
+#   # Debugging the decoder
+#   - git clone -b ${cgra_branch} -- ${cgra_git}
+#   - BS=${TRAVIS_BUILD_DIR}/CGRAGenerator/bitstream
+#   - ls -l ${BS}
+#   - ls -l ${BS}/decoder
+#   - ls -l ${BS}/decoder/lib
+#   - export PYTHONPATH=${BS}/decoder/:${PYTHONPATH}
+#   - ${BS}/decoder/decode.py ${BS}/example3/PNRguys_config.dat
+# 
 
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -164,6 +164,21 @@ script:
 
 
 
+
+
+
+  # Look at Caleb's bitstream
+  - ls -l ../../pnr_bitstream ../../build/mapped.xml
+  - cat ../../build/mapped.xml
+  - cat ../../pnr_bitstream
+
+  # Decode Caleb's bitstream
+  BS=${TRAVIS_BUILD_DIR}/CGRAGenerator/
+  ${BS}/decoder/decode.py ../../pnr_bitstream
+
+
+  # Build Ankita bitstream for comparison
+
   # bitstream build
   # IN:  mapped.xml    (Sparse connection matrix map from PNR)
   # OUT: config.dat    (Bitstream for programming CGRA)
@@ -179,6 +194,11 @@ script:
        ${TRAVIS_BUILD_DIR}/build/mapped.xml
        ${TRAVIS_BUILD_DIR}/build/config
        || exit -1
+
+  # Decode Ankita's bitstream
+  BS=${TRAVIS_BUILD_DIR}/CGRAGenerator/
+  ${BS}/decoder/decode.py ${TRAVIS_BUILD_DIR}/build/config.dat
+
 
 
   ##############################################################################

--- a/.travis.yml
+++ b/.travis.yml
@@ -151,8 +151,8 @@ script:
   # IN:  mapped.json      # Output from mapper
   #      cgra_info.txt    # Fully-populated connection matrix from CGRA generator
   #
-  # OUT: mapped.xml       # Sparse connection matrix map for CGRA
-  #      io.xml           # I/O pin information for CGRA
+  # OUT: mapped.xml       # [DEPRECATED] Sparse connection matrix map for CGRA
+  #      io.xml           # [DEPRECATED] I/O pin information for CGRA
   #      pnr_bitstream    # bitstream file
   #
   - cd ${TRAVIS_BUILD_DIR}/smt-pnr/src/
@@ -162,43 +162,42 @@ script:
     --xml ../../build/mapped.xml ../../build/io.xml
     --bitstream ../../pnr_bitstream
 
-  # FIXME note caleb's script puts output in ../../ instead of ../../build/
-
-  # Look at Caleb's bitstream
-  - ls -l ../../pnr_bitstream ../../build/mapped.xml
-  - cat ../../build/mapped.xml
-  - cat ../../pnr_bitstream
-
-  # Decode Caleb's bitstream
-  - BS=${TRAVIS_BUILD_DIR}/CGRAGenerator/bitstream
-  - ls -l ${BS}/decoder/lib
-  - export PYTHONPATH=${BS}/decoder/:${PYTHONPATH}
-  - ${BS}/decoder/decode.py ../../pnr_bitstream
-
-
-  # Build Ankita bitstream for comparison
-
-  # bitstream build (ankita perl script)
-  # IN:  mapped.xml    (Sparse connection matrix map from PNR)
-  # OUT: config.dat    (Bitstream for programming CGRA)
-  # 
-  # FIXME this is a terrible place for the perl script to live
-  # FIXME don't worry soon it will be replaced by Caleb's script
-  #
-  - echo "Build bitstream for programming CGRA" - `date`
-  - GENBS=${TRAVIS_BUILD_DIR}/CGRAGenerator/bitstream/example3/
-  - ls -l ${GENBS}/gen_bitstream.pl
-       ${TRAVIS_BUILD_DIR}/build/mapped.xml
-  - perl ${GENBS}/gen_bitstream.pl
-       ${TRAVIS_BUILD_DIR}/build/mapped.xml
-       ${TRAVIS_BUILD_DIR}/build/config
-       || exit -1
-
-  # Decode Ankita's bitstream
-  - BS=${TRAVIS_BUILD_DIR}/CGRAGenerator/bitstream
-  - export PYTHONPATH=${BS}/decoder/:${PYTHONPATH}
-  - ${BS}/decoder/decode.py ${TRAVIS_BUILD_DIR}/build/config.dat
-
+#   # FIXME note caleb's script puts output in ../../ instead of ../../build/ (above)
+# 
+#   # Look at Caleb's bitstream
+#   - ls -l ../../pnr_bitstream ../../build/mapped.xml
+#   - cat ../../build/mapped.xml
+#   - cat ../../pnr_bitstream
+# 
+#   # Decode Caleb's bitstream
+#   - BS=${TRAVIS_BUILD_DIR}/CGRAGenerator/bitstream
+#   - ls -l ${BS}/decoder/lib
+#   - export PYTHONPATH=${BS}/decoder/:${PYTHONPATH}
+#   - ${BS}/decoder/decode.py ../../pnr_bitstream
+# 
+# 
+#   # Build Ankita bitstream for comparison
+# 
+#   # bitstream build (ankita perl script)
+#   # IN:  mapped.xml    (Sparse connection matrix map from PNR)
+#   # OUT: config.dat    (Bitstream for programming CGRA)
+#   # 
+#   # FIXME this is a terrible place for the perl script to live
+#   # FIXME don't worry soon it will be replaced by Caleb's script
+#   #
+#   - echo "Build bitstream for programming CGRA" - `date`
+#   - GENBS=${TRAVIS_BUILD_DIR}/CGRAGenerator/bitstream/example3/
+#   - ls -l ${GENBS}/gen_bitstream.pl
+#        ${TRAVIS_BUILD_DIR}/build/mapped.xml
+#   - perl ${GENBS}/gen_bitstream.pl
+#        ${TRAVIS_BUILD_DIR}/build/mapped.xml
+#        ${TRAVIS_BUILD_DIR}/build/config
+#        || exit -1
+# 
+#   # Decode Ankita's bitstream
+#   - BS=${TRAVIS_BUILD_DIR}/CGRAGenerator/bitstream
+#   - export PYTHONPATH=${BS}/decoder/:${PYTHONPATH}
+#   - ${BS}/decoder/decode.py ${TRAVIS_BUILD_DIR}/build/config.dat
 
 
   ##############################################################################

--- a/.travis.yml
+++ b/.travis.yml
@@ -133,7 +133,8 @@ script:
   #
   - cd ${TRAVIS_BUILD_DIR}/smt-pnr/src/
 
-#   - ./test.py --help
+  - pip install smt_switch
+  - ./test.py --help
 
   - ./test.py --print
     ../../build/mapped.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -138,7 +138,8 @@ script:
     --xml ../../build/mapped.xml ../../build/io.xml
     --bitstream ../../pnr_bitstream
 
-  - ls -l ../../pnr_bitstream
+  - ls -l ../../pnr_bitstream ../../build/mapped.xml
+  - cat ../../build/mapped.xml
   - cat ../../pnr_bitstream
 
   # bitstream build
@@ -150,8 +151,7 @@ script:
   #
   - echo "Build bitstream for programming CGRA" - `date`
   - EXAMPLE3=${TRAVIS_BUILD_DIR}/CGRAGenerator/bitstream/example3
-  - ls -l ${EXAMPLE3}/gen_bitstream.pl
-       ${TRAVIS_BUILD_DIR}/build/mapped.xml
+  - ls -l ${TRAVIS_BUILD_DIR}/build/mapped.xml
   - perl ${EXAMPLE3}/gen_bitstream.pl
        ${TRAVIS_BUILD_DIR}/build/mapped.xml
        ${TRAVIS_BUILD_DIR}/build/config

--- a/.travis.yml
+++ b/.travis.yml
@@ -133,7 +133,7 @@ script:
   #
   - cd ${TRAVIS_BUILD_DIR}/smt-pnr/src/
 
-  - ./test.py --help
+#   - ./test.py --help
 
   - ./test.py --print
     ../../build/mapped.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -162,19 +162,14 @@ script:
     --xml ../../build/mapped.xml ../../build/io.xml
     --bitstream ../../pnr_bitstream
 
-
-
-
-
-
   # Look at Caleb's bitstream
   - ls -l ../../pnr_bitstream ../../build/mapped.xml
   - cat ../../build/mapped.xml
   - cat ../../pnr_bitstream
 
   # Decode Caleb's bitstream
-  BS=${TRAVIS_BUILD_DIR}/CGRAGenerator/
-  ${BS}/decoder/decode.py ../../pnr_bitstream
+  - BS=${TRAVIS_BUILD_DIR}/CGRAGenerator/
+  - ${BS}/decoder/decode.py ../../pnr_bitstream
 
 
   # Build Ankita bitstream for comparison
@@ -196,8 +191,8 @@ script:
        || exit -1
 
   # Decode Ankita's bitstream
-  BS=${TRAVIS_BUILD_DIR}/CGRAGenerator/
-  ${BS}/decoder/decode.py ${TRAVIS_BUILD_DIR}/build/config.dat
+  - BS=${TRAVIS_BUILD_DIR}/CGRAGenerator/
+  - ${BS}/decoder/decode.py ${TRAVIS_BUILD_DIR}/build/config.dat
 
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -162,7 +162,7 @@ script:
     --xml ../../build/mapped.xml ../../build/io.xml
     --bitstream ../../pnr_bitstream
 
-#   # FIXME note caleb's script puts output in ../../ instead of ../../build/ (above)
+#   # FIXME note caleb's script (above) puts output in ../../ instead of ../../build/
 
   ##############################################################################
   # Little temporary hack to get around instabilities above when/if needed.
@@ -171,7 +171,6 @@ script:
   # - cp ${EXAMPLE3}/PNRguys_io.xml     ${TRAVIS_BUILD_DIR}/build/io.xml;
   ##############################################################################
 
-  # Try again using caleb bitstream?
   # cgra program and run (caleb bitstream)
   # IN:  pnr_bitstream (Bitstream for programming CGRA)
   #      input.png     (Input image)

--- a/.travis.yml
+++ b/.travis.yml
@@ -207,20 +207,20 @@ script:
   # - cp ${EXAMPLE3}/PNRguys_io.xml     ${TRAVIS_BUILD_DIR}/build/io.xml;
   ##############################################################################
 
-  # cgra program and run (ankita)
-  # IN:  config.dat    (Bitstream for programming CGRA)
-  #      io.xml        (I/O pin information for CGRA)
-  #      input.png     (Input image)
-  # OUT: CGRA_out.raw  (Output image)
-  #
-  - echo "CGRA program and run (uses output of pnr)" - `date`
-  - cd ${TRAVIS_BUILD_DIR}/CGRAGenerator/verilator/generator_z_tb
-  - ./run.csh top_tb.cpp
-        -config ${TRAVIS_BUILD_DIR}/build/config.dat
-        -io     ${TRAVIS_BUILD_DIR}/build/io.xml
-        -input  ${TRAVIS_BUILD_DIR}/build/input.png
-        -output ${TRAVIS_BUILD_DIR}/build/CGRA_out.raw
-        -nclocks 5M
+#   # cgra program and run (ankita)
+#   # IN:  config.dat    (Bitstream for programming CGRA)
+#   #      io.xml        (I/O pin information for CGRA)
+#   #      input.png     (Input image)
+#   # OUT: CGRA_out.raw  (Output image)
+#   #
+#   - echo "CGRA program and run (uses output of pnr)" - `date`
+#   - cd ${TRAVIS_BUILD_DIR}/CGRAGenerator/verilator/generator_z_tb
+#   - ./run.csh top_tb.cpp
+#         -config ${TRAVIS_BUILD_DIR}/build/config.dat
+#         -io     ${TRAVIS_BUILD_DIR}/build/io.xml
+#         -input  ${TRAVIS_BUILD_DIR}/build/input.png
+#         -output ${TRAVIS_BUILD_DIR}/build/CGRA_out.raw
+#         -nclocks 5M
 
   # Try again using caleb bitstream?
   # cgra program and run (caleb)

--- a/scripts/brancher.sh
+++ b/scripts/brancher.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+REPOS=(halide coreir mapper cgra pnr smt)  
+DIR="$(dirname $0)/../"
+TRAVIS=".travis.yml"
+
+if [ ! -d $DIR ] ; then
+    echo "Could not locate CGRAFlow directory"
+    exit 1
+else
+    cd $DIR
+fi
+
+if [ ! -f $TRAVIS ]; then
+    echo "Could not locate .travis.yml"
+    exit 1
+fi
+
+function usage() {
+    echo "(<${REPOS[*]}> <BRANCH_NAME>)+"
+}
+
+function elem_in() {
+    local e
+    elem="${1}"
+    shift
+    arr=("${@}")
+    for e in ${arr[*]}; do 
+        if [[ "$e" == "$elem" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+
+
+if [[ $# -eq 0 ]] || [[ $(( $# % 2 )) -ne 0 ]]; then
+    usage
+	exit 1
+fi
+
+argv=( $@ )
+
+# for i from 0 to n-1
+for i in $(seq 0 $(( $# -1 )) ); do
+    # if i % 2 == 0 
+    if [[ $(( $i % 2 )) -eq 0 ]] ; then
+        # check if subproject is in REPOS
+        if ! elem_in ${argv[$i]} ${REPOS[*]} ; then
+            echo bad subproject ${argv[$i]} 
+            usage
+            exit 1
+        fi
+    fi
+done
+
+s=""
+# for i from 0 to n-1
+for i in $(seq 0 $(( $# -1 )) ); do
+    if [ -n "$s" ]; then
+        s+="_"
+    fi
+    s+="${argv[$i]}"
+done
+
+current_branch=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD)
+git checkout -b "$s"
+
+# for i from 0 to n-1
+for i in $(seq 0 $(( $# -1 )) ); do
+    # if i % 2 == 0 
+    if [[ $(( $i % 2 )) -eq 0 ]] ; then
+        sp="${argv[$i]}"
+    else
+        b="${argv[$i]}"
+        echo $sp $b
+        sed -r "s/(${sp}_branch)=.+/\1=\"${b}\"/" -i $TRAVIS
+    fi
+done
+
+git add $TRAVIS
+git commit -m "Auto generated branch"
+git push --set-upstream origin "$s"
+git checkout $current_branch

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+REPOS=(halide coreir mapper cgra pnr smt)  
+DIR="$(dirname $0)/../"
+
+if [ ! -d $DIR ] ; then
+    echo "Could not locate CGRAFlow directory"
+    exit 1
+else
+    cd $DIR
+fi
+
+function usage() {
+    echo "(<${REPOS[*]}> <BRANCH_NAME>)+"
+}
+
+function elem_in() {
+    local e
+    elem="${1}"
+    shift
+    arr=("${@}")
+
+    for e in ${arr[*]}; do 
+        if [[ "$e" == "$elem" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+
+
+if [[ $# -eq 0 ]] || [[ $(( $# % 2 )) -ne 0 ]]; then
+    usage
+	exit 1
+fi
+
+argv=( $@ )
+
+# for i from 0 to n-1
+for i in $(seq 0 $(( $# -1 )) ); do
+    # if i % 2 == 0 
+    if [[ $(( $i % 2 )) -eq 0 ]] ; then
+        # check if subproject is in REPOS
+        if ! elem_in ${argv[$i]} ${REPOS[*]} ; then
+            echo bad subproject ${argv[$i]} 
+            usage
+            exit 1
+        fi
+    fi
+done
+
+s=""
+# for i from 0 to n-1
+for i in $(seq 0 $(( $# -1 )) ); do
+    if [ -n "$s" ]; then
+        s+="_"
+    fi
+    s+="${argv[$i]}"
+done
+
+git branch -d "$s"
+git push origin --delete "$s"


### PR DESCRIPTION
Simplified the flow by removing Ankita's bitstream-generating script in favor of using the bitstream generated directly from PNR.  The change itself is pretty tiny...here's a quick summary of what I did:

* marked test.py XML outputs io.xml and mapped.xml as DEPRECATED in the comments

* cut out the part that used ankita's perl script that used mapped.xml to produce the bitstream;

* run.csh script now reads test.py output "pnr_bitstream" directly, instead of config.dat, and uses "pnr_bitstream" to derive io info instead of reading io.xml.

See your email for details...

