### PR TITLE
Srcleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,6 +92,11 @@ script:
   # - export CGRA_GEN_ALL_REG=1
   - make
 
+# What if we make a summary of the test results, to print out at the end?
+after_script:
+  - echo hello i am the after script
+  - if `test -e build/test_summary.txt`; then cat build/test_summary.txt; fi
+
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,7 +90,7 @@ script:
   # Uncomment one or both of these next two lines when ready for mem tiles
   # - export CGRA_GEN_USE_MEM=1
   # - export CGRA_GEN_ALL_REG=1
-  - make
+  - make -n
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,7 +90,7 @@ script:
   # Uncomment one or both of these next two lines when ready for mem tiles
   # - export CGRA_GEN_USE_MEM=1
   # - export CGRA_GEN_ALL_REG=1
-  - make -n
+  - make
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,10 +87,8 @@ script:
   # "set -e" means "die at first error" - seems like a good idea!
   - set -e
 
-  # Uncomment one or both of these next two lines when ready for mem tiles
-  # - export CGRA_GEN_USE_MEM=1
-  # - export CGRA_GEN_ALL_REG=1
-  - make
+  # - make CGRA_SIZE=4x4
+  - make CGRA_SIZE=8x8
 
 # What if we make a summary of the test results, to print out at the end?
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,13 +87,17 @@ script:
   # "set -e" means "die at first error" - seems like a good idea!
   - set -e
 
-  # - make CGRA_SIZE=4x4
-  - make CGRA_SIZE=8x8
+  - make CGRA_SIZE=4x4
 
-# What if we make a summary of the test results, to print out at the end?
+  # Does not work (yet); problems with bitstream generation
+  # - make CGRA_SIZE=8x8 build/pointwise.correct.txt
+
 after_script:
-  - echo hello i am the after script
+  # The log file is getting very long and unwieldy.
+  # What if we make a summary of the test results, to print out at the end?
+  # Also see https://docs.travis-ci.com/user/customizing-the-build/
   - if `test -e build/test_summary.txt`; then cat build/test_summary.txt; fi
+
 
 addons:
   apt:

--- a/makefile
+++ b/makefile
@@ -1,14 +1,24 @@
 CONVERT = CGRAGenerator/verilator/generator_z_tb/io/myconvert.csh
 
+########################################################################
 # For 8x8 CGRA grid, change CGRA_SIZE from "4x4" to "8x8"
+# E.g. "make CGRA_SIZE=8x8"
+
+# For now, default is "4x4"
 CGRA_SIZE := "4x4"
-MEM_SWITCH = "-oldmem"
+MEM_SWITCH := "-oldmem"  # Don't really need this...riiight?
+
+ifeq ($(CGRA_SIZE),"4x4")
+  MEM_SWITCH := "-oldmem"
+endif
+
 ifeq ($(CGRA_SIZE),"8x8")
-  MEM_SWITCH = "-newmem"
+  MEM_SWITCH := "-newmem"
 endif
 
 $(warning CGRA_SIZE = $(CGRA_SIZE))
 $(warning MEM_SWITCH = $(MEM_SWITCH))
+########################################################################
 
 
 all: build/pointwise.correct.txt build/conv_bw_mapped.json build/cascade_mapped.json
@@ -87,15 +97,18 @@ build/%_pnr_bitstream: build/%_mapped.json build/cgra_info_4x4.txt
         #      annotated        # annotated bitstream file
         #- cd ${TRAVIS_BUILD_DIR}/smt-pnr/src/
 
-#	smt-pnr/src/test.py  build/$*_mapped.json CGRAGenerator/hardware/generator_z/top/cgra_info.txt --bitstream build/$*_pnr_bitstream --annotate build/$*_annotated --print  --coreir-libs stdlib cgralib
+	@echo; echo Making $@ because of $?
+	ls -l CGRAGenerator/hardware/generator_z/top/cgra_info.txt build/cgra_info_4x4.txt
+	diff CGRAGenerator/hardware/generator_z/top/cgra_info.txt build/cgra_info_4x4.txt
+
+
+	smt-pnr/src/test.py  build/$*_mapped.json CGRAGenerator/hardware/generator_z/top/cgra_info.txt --bitstream build/$*_pnr_bitstream --annotate build/$*_annotated --print  --coreir-libs stdlib cgralib
 # 	smt-pnr/src/test.py  \
 # 	  build/$*_mapped.json \
 # 	  CGRAGenerator/hardware/generator_z/top/cgra_info.txt \
 # 	  --bitstream build/$*_pnr_bitstream \
 # 	  --annotate build/$*_annotated      \
 #	  --print  --coreir-libs stdlib cgralib
-
-	@echo; echo Making $@ because of $?
 
         # $(filter %.txt,  $?) => config file   e.g. "build/cgra_info_4x4.txt"
         # $(filter %.json, $?) => program graph e.g. "build/pointwise_mapped.json"

--- a/makefile
+++ b/makefile
@@ -23,7 +23,7 @@ build/%_design_top.json: Halide_CoreIR/apps/coreir_examples/%
   # as well as the DAG "design_top.json" for the mapper.
   #
 
-	@echo Making $@ because of $?
+	@echo; echo Making $@ because of $?
         # I think e.g. '$*' == "pointwise" when building e.g. "build/pointwise/correct.txt"
         # remake the json and cpu output image for our test app
 	make -C Halide_CoreIR/apps/coreir_examples/$*/ clean design_top.json out.png
@@ -59,20 +59,20 @@ build/%_mapped.json: build/%_design_top.json
   # to produce a mapped version "mapped.json" for the PNR folks.  Right?
   #
 
-	@echo Making $@ because of $?
+	@echo; echo Making $@ because of $?
 	echo "MAPPER"
 	./CGRAMapper/bin/map build/$*_design_top.json build/$*_mapped.json
 	ls -la build
 	cat build/$*_mapped.json
 
 build/cgra_info_4x4.txt:
-	@echo Making $@ because of $?
+	@echo; echo Making $@ because of $?
 	@echo "CGRA generate (generates 4x4 CGRA + connection matrix for pnr)"
 	cd CGRAGenerator; ./bin/generate.csh || exit -1
 	cp CGRAGenerator/hardware/generator_z/top/cgra_info.txt build/cgra_info_4x4.txt
 
 build/cgra_info_8x8.txt:
-	@echo Making $@ because of $?
+	@echo; echo Making $@ because of $?
 	@echo "CGRA generate (generates 8x8 CGRA + connection matrix for pnr)"
 	cd CGRAGenerator; export CGRA_GEN_USE_MEM=1; ./bin/generate.csh || exit -1
 	cp CGRAGenerator/hardware/generator_z/top/cgra_info.txt build/cgra_info_8x8.txt
@@ -90,7 +90,7 @@ build/%_pnr_bitstream: build/%_mapped.json build/cgra_info_4x4.txt
 # 	smt-pnr/src/test.py  build/$*_mapped.json CGRAGenerator/hardware/generator_z/top/cgra_info.txt --bitstream build/$*_pnr_bitstream --annotate build/$*_annotated --print  --coreir-libs stdlib cgralib
         # filter (below) auto-extracts cgra_info file from dependency list maybe
         # I think $(word 2,$?) will return second dependence thingy
-	@echo Making $@ because of $?
+	@echo; echo Making $@ because of $?
 	\
 	set config=$(filter %.txt,$?); \
 	set graph=$(filter %.json,$?); \
@@ -117,7 +117,7 @@ build/%_CGRA_out.raw: build/%_pnr_bitstream
   #      input.png     (Input image)
   # OUT: CGRA_out.raw  (Output image)
 
-	@echo Making $@ because of $?
+	@echo; echo Making $@ because of $?
 	echo "CGRA program and run (uses output of pnr)"
 
 # 	cd CGRAGenerator/verilator/generator_z_tb;  \
@@ -136,7 +136,7 @@ build/%_CGRA_out.raw: build/%_pnr_bitstream
 build/%.correct.txt: build/%_CGRA_out.raw
   # check to see that output is correct.
 
-	@echo Making $@ because of $?
+	@echo; echo Making $@ because of $?
 	echo "BYTE-BY-BYTE COMPARE OF CGRA VS. HALIDE OUTPUT IMAGES"
 	ls -l build/*.raw
 	cmp   build/$*_halide_out.raw  build/$*_CGRA_out.raw

--- a/makefile
+++ b/makefile
@@ -78,6 +78,7 @@ build/%_pnr_bitstream: build/%_mapped.json build/cgra_info_4x4.txt
         #- cd ${TRAVIS_BUILD_DIR}/smt-pnr/src/
         # 
 # 	smt-pnr/src/test.py  build/$*_mapped.json CGRAGenerator/hardware/generator_z/top/cgra_info.txt --bitstream build/$*_pnr_bitstream --annotate build/$*_annotated --print  --coreir-libs stdlib cgralib
+	echo $(filter %.txt,$?)
 	smt-pnr/src/test.py  \
 	    build/$*_mapped.json \
 	    build/cgra_info_4x4.txt \

--- a/makefile
+++ b/makefile
@@ -12,6 +12,8 @@ build/%_design_top.json: Halide_CoreIR/apps/coreir_examples/%
   # as well as the DAG "design_top.json" for the mapper.
   #
 
+        # I think e.g. $* == "pointwise" when building e.g. "build/pointwise/correct.txt"
+	@echo Making $@ because of $?
 	# remake the json and cpu output image for our test app
 	make -C Halide_CoreIR/apps/coreir_examples/$*/ clean design_top.json out.png
 	# copy over all pertinent files

--- a/makefile
+++ b/makefile
@@ -115,8 +115,8 @@ build/%_pnr_bitstream: build/%_mapped.json build/cgra_info_4x4.txt
         # (Could also maybe use $(word 1, $?) and $(word 2, $?)
 	\
 	smt-pnr/src/test.py       \
-	    $(filter %.txt ,$?)   \
 	    $(filter %.json,$?)   \
+	    $(filter %.txt ,$?)   \
 	    --bitstream build/$*_pnr_bitstream \
 	    --annotate build/$*_annotated \
 	    --print --coreir-libs stdlib cgralib

--- a/makefile
+++ b/makefile
@@ -104,8 +104,8 @@ build/%_pnr_bitstream: build/%_mapped.json build/cgra_info_$(CGRA_SIZE).txt
         #- cd ${TRAVIS_BUILD_DIR}/smt-pnr/src/
 
 	@echo; echo Making $@ because of $?
-	ls -l CGRAGenerator/hardware/generator_z/top/cgra_info.txt build/cgra_info_4x4.txt
-	diff CGRAGenerator/hardware/generator_z/top/cgra_info.txt build/cgra_info_4x4.txt
+# 	ls -l CGRAGenerator/hardware/generator_z/top/cgra_info.txt $(filter %.txt, $?)
+# 	diff CGRAGenerator/hardware/generator_z/top/cgra_info.txt $(filter %.txt, $?)
 
 
 # 	smt-pnr/src/test.py  build/$*_mapped.json CGRAGenerator/hardware/generator_z/top/cgra_info.txt --bitstream build/$*_pnr_bitstream --annotate build/$*_annotated --print  --coreir-libs stdlib cgralib

--- a/makefile
+++ b/makefile
@@ -6,13 +6,13 @@ CONVERT = CGRAGenerator/verilator/generator_z_tb/io/myconvert.csh
 
 # For now, default is "4x4"
 CGRA_SIZE := 4x4
-MEM_SWITCH := "-oldmem"  # Don't really need this...riiight?
+MEM_SWITCH := -oldmem  # Don't really need this...riiight?
 
-ifeq ($(CGRA_SIZE),"4x4")
+ifeq ($(CGRA_SIZE), 4x4)
   MEM_SWITCH := -oldmem
 endif
 
-ifeq ($(CGRA_SIZE),"8x8")
+ifeq ($(CGRA_SIZE), 8x8)
   MEM_SWITCH := -newmem
 endif
 

--- a/makefile
+++ b/makefile
@@ -94,7 +94,14 @@ build/%_pnr_bitstream: build/%_mapped.json build/cgra_info_4x4.txt
 	  build/$*_mapped.json \
 	  CGRAGenerator/hardware/generator_z/top/cgra_info.txt \
 	  --bitstream build/$*_pnr_bitstream \
-	  --annotate build/$*_annotated \
+	  --annotate build/$*_annotated      \
+	  --print  --coreir-libs stdlib cgralib
+
+	smt-pnr/src/test.py     \
+	  build/$*_mapped.json   \
+	  build/cgra_info_4x4.txt \
+	  --bitstream build/$*_pnr_bitstream \
+	  --annotate build/$*_annotated      \
 	  --print  --coreir-libs stdlib cgralib
 
 # 	build/$*_mapped.json 
@@ -111,14 +118,16 @@ build/%_pnr_bitstream: build/%_mapped.json build/cgra_info_4x4.txt
 	set config=$(filter %.txt,$?); \
 	set graph=$(filter %.json,$?); \
 	echo smt-pnr/src/test.py  \
-	    $${graph}  \
-	    $${config} \
+	    $(filter %.txt ,$?)   \
+	    $(filter %.json,$?)   \
 	    --bitstream build/$*_pnr_bitstream \
 	    --annotate build/$*_annotated \
 	    --print --coreir-libs stdlib cgralib
-	smt-pnr/src/test.py  \
-	    $${graph}  \
-	    $${config} \
+
+	\
+	smt-pnr/src/test.py       \
+	    $(filter %.txt ,$?)   \
+	    $(filter %.json,$?)   \
 	    --bitstream build/$*_pnr_bitstream \
 	    --annotate build/$*_annotated \
 	    --print --coreir-libs stdlib cgralib

--- a/makefile
+++ b/makefile
@@ -79,9 +79,10 @@ build/%_pnr_bitstream: build/%_mapped.json build/cgra_info_4x4.txt
         # 
 # 	smt-pnr/src/test.py  build/$*_mapped.json CGRAGenerator/hardware/generator_z/top/cgra_info.txt --bitstream build/$*_pnr_bitstream --annotate build/$*_annotated --print  --coreir-libs stdlib cgralib
 	echo $(filter %.txt,$?)
+	set config=$(filter %.txt,$?); \
 	smt-pnr/src/test.py  \
 	    build/$*_mapped.json \
-	    build/cgra_info_4x4.txt \
+	    $${config} \
 	    --bitstream build/$*_pnr_bitstream \
 	    --annotate build/$*_annotated \
 	    --print --coreir-libs stdlib cgralib
@@ -95,7 +96,7 @@ build/%_pnr_bitstream: build/%_mapped.json build/cgra_info_4x4.txt
   # - cp ${EXAMPLE3}/PNRguys_io.xml     ${TRAVIS_BUILD_DIR}/build/io.xml;
   ##############################################################################
 
-VERILATOR_TOP := CGRAGenerator/verilator/generator_z_tb;
+VERILATOR_TOP := CGRAGenerator/verilator/generator_z_tb
 build/%_CGRA_out.raw: build/%_pnr_bitstream
   # cgra program and run (caleb bitstream)
   # IN:  pnr_bitstream (Bitstream for programming CGRA)

--- a/makefile
+++ b/makefile
@@ -5,15 +5,15 @@ CONVERT = CGRAGenerator/verilator/generator_z_tb/io/myconvert.csh
 # E.g. "make CGRA_SIZE=8x8"
 
 # For now, default is "4x4"
-CGRA_SIZE := "4x4"
+CGRA_SIZE := 4x4
 MEM_SWITCH := "-oldmem"  # Don't really need this...riiight?
 
 ifeq ($(CGRA_SIZE),"4x4")
-  MEM_SWITCH := "-oldmem"
+  MEM_SWITCH := -oldmem
 endif
 
 ifeq ($(CGRA_SIZE),"8x8")
-  MEM_SWITCH := "-newmem"
+  MEM_SWITCH := -newmem
 endif
 
 $(warning CGRA_SIZE = $(CGRA_SIZE))

--- a/makefile
+++ b/makefile
@@ -1,5 +1,16 @@
 CONVERT = CGRAGenerator/verilator/generator_z_tb/io/myconvert.csh
 
+# For 8x8 CGRA grid, change CGRA_SIZE from "4x4" to "8x8"
+CGRA_SIZE := "4x4"
+MEM_SWITCH = "-oldmem"
+ifeq ($(CGRA_SIZE),"8x8")
+  MEM_SWITCH = "-newmem"
+endif
+
+$(warning CGRA_SIZE = $(CGRA_SIZE))
+$(warning MEM_SWITCH = $(MEM_SWITCH))
+
+
 all: build/pointwise.correct.txt build/conv_bw_mapped.json build/cascade_mapped.json
 
 build/%_design_top.json: Halide_CoreIR/apps/coreir_examples/%
@@ -63,7 +74,7 @@ build/cgra_info_4x4.txt:
 build/cgra_info_8x8.txt:
 	@echo Making $@ because of $?
 	@echo "CGRA generate (generates 8x8 CGRA + connection matrix for pnr)"
-	cd CGRAGenerator; ./bin/generate.csh || exit -1
+	cd CGRAGenerator; export CGRA_GEN_USE_MEM=1; ./bin/generate.csh || exit -1
 	cp CGRAGenerator/hardware/generator_z/top/cgra_info.txt build/cgra_info_8x8.txt
 
 build/%_pnr_bitstream: build/%_mapped.json build/cgra_info_4x4.txt

--- a/makefile
+++ b/makefile
@@ -86,44 +86,20 @@ build/%_pnr_bitstream: build/%_mapped.json build/cgra_info_4x4.txt
         # OUT: pnr_bitstream    # bitstream file
         #      annotated        # annotated bitstream file
         #- cd ${TRAVIS_BUILD_DIR}/smt-pnr/src/
-        # 
 
-	smt-pnr/src/test.py  build/$*_mapped.json CGRAGenerator/hardware/generator_z/top/cgra_info.txt --bitstream build/$*_pnr_bitstream --annotate build/$*_annotated --print  --coreir-libs stdlib cgralib
+#	smt-pnr/src/test.py  build/$*_mapped.json CGRAGenerator/hardware/generator_z/top/cgra_info.txt --bitstream build/$*_pnr_bitstream --annotate build/$*_annotated --print  --coreir-libs stdlib cgralib
+# 	smt-pnr/src/test.py  \
+# 	  build/$*_mapped.json \
+# 	  CGRAGenerator/hardware/generator_z/top/cgra_info.txt \
+# 	  --bitstream build/$*_pnr_bitstream \
+# 	  --annotate build/$*_annotated      \
+#	  --print  --coreir-libs stdlib cgralib
 
-	smt-pnr/src/test.py  \
-	  build/$*_mapped.json \
-	  CGRAGenerator/hardware/generator_z/top/cgra_info.txt \
-	  --bitstream build/$*_pnr_bitstream \
-	  --annotate build/$*_annotated      \
-	  --print  --coreir-libs stdlib cgralib
-
-	smt-pnr/src/test.py     \
-	  build/$*_mapped.json   \
-	  build/cgra_info_4x4.txt \
-	  --bitstream build/$*_pnr_bitstream \
-	  --annotate build/$*_annotated      \
-	  --print  --coreir-libs stdlib cgralib
-
-# 	build/$*_mapped.json 
-# 	CGRAGenerator/hardware/generator_z/top/cgra_info.txt 
-# 	--bitstream build/$*_pnr_bitstream 
-# 	--annotate build/$*_annotated 
-# 	--print  
-# 	--coreir-libs stdlib cgralib
-
-        # filter (below) auto-extracts cgra_info file from dependency list maybe
-        # I think $(word 2,$?) will return second dependence thingy
 	@echo; echo Making $@ because of $?
-	\
-	config=$(filter %.txt, $?); \
-	graph=$(filter  %.json,$?); \
-	echo smt-pnr/src/test.py  \
-	    $(filter %.txt ,$?)   \
-	    $(filter %.json,$?)   \
-	    --bitstream build/$*_pnr_bitstream \
-	    --annotate build/$*_annotated \
-	    --print --coreir-libs stdlib cgralib
 
+        # $(filter %.txt,  $?) => config file   e.g. "build/cgra_info_4x4.txt"
+        # $(filter %.json, $?) => program graph e.g. "build/pointwise_mapped.json"
+        # (Could also maybe use $(word 1, $?) and $(word 2, $?)
 	\
 	smt-pnr/src/test.py       \
 	    $(filter %.txt ,$?)   \
@@ -133,15 +109,6 @@ build/%_pnr_bitstream: build/%_mapped.json build/cgra_info_4x4.txt
 	    --print --coreir-libs stdlib cgralib
 
 	cat build/$*_annotated
-
-# 	set config=build/cgra_info_4x4.txt; \
-# 	set graph=build/pointwise_mapped.json; \
-# 	smt-pnr/src/test.py  \
-# 	    ${graph}  \
-# 	    ${config} \
-# 	    --bitstream build/pointwise_pnr_bitstream \
-# 	    --annotate build/pointwise_annotated \
-# 	    --print --coreir-libs stdlib cgralib
 
   ##############################################################################
   # Little temporary hack to get around instabilities above when/if needed.

--- a/makefile
+++ b/makefile
@@ -87,13 +87,35 @@ build/%_pnr_bitstream: build/%_mapped.json build/cgra_info_4x4.txt
         #      annotated        # annotated bitstream file
         #- cd ${TRAVIS_BUILD_DIR}/smt-pnr/src/
         # 
-# 	smt-pnr/src/test.py  build/$*_mapped.json CGRAGenerator/hardware/generator_z/top/cgra_info.txt --bitstream build/$*_pnr_bitstream --annotate build/$*_annotated --print  --coreir-libs stdlib cgralib
+
+	smt-pnr/src/test.py  build/$*_mapped.json CGRAGenerator/hardware/generator_z/top/cgra_info.txt --bitstream build/$*_pnr_bitstream --annotate build/$*_annotated --print  --coreir-libs stdlib cgralib
+
+	smt-pnr/src/test.py  \
+	  build/$*_mapped.json \
+	  CGRAGenerator/hardware/generator_z/top/cgra_info.txt \
+	  --bitstream build/$*_pnr_bitstream \
+	  --annotate build/$*_annotated \
+	  --print  --coreir-libs stdlib cgralib
+
+# 	build/$*_mapped.json 
+# 	CGRAGenerator/hardware/generator_z/top/cgra_info.txt 
+# 	--bitstream build/$*_pnr_bitstream 
+# 	--annotate build/$*_annotated 
+# 	--print  
+# 	--coreir-libs stdlib cgralib
+
         # filter (below) auto-extracts cgra_info file from dependency list maybe
         # I think $(word 2,$?) will return second dependence thingy
 	@echo; echo Making $@ because of $?
 	\
 	set config=$(filter %.txt,$?); \
 	set graph=$(filter %.json,$?); \
+	echo smt-pnr/src/test.py  \
+	    $${graph}  \
+	    $${config} \
+	    --bitstream build/$*_pnr_bitstream \
+	    --annotate build/$*_annotated \
+	    --print --coreir-libs stdlib cgralib
 	smt-pnr/src/test.py  \
 	    $${graph}  \
 	    $${config} \
@@ -102,6 +124,15 @@ build/%_pnr_bitstream: build/%_mapped.json build/cgra_info_4x4.txt
 	    --print --coreir-libs stdlib cgralib
 
 	cat build/$*_annotated
+
+# 	set config=build/cgra_info_4x4.txt; \
+# 	set graph=build/pointwise_mapped.json; \
+# 	smt-pnr/src/test.py  \
+# 	    ${graph}  \
+# 	    ${config} \
+# 	    --bitstream build/pointwise_pnr_bitstream \
+# 	    --annotate build/pointwise_annotated \
+# 	    --print --coreir-libs stdlib cgralib
 
   ##############################################################################
   # Little temporary hack to get around instabilities above when/if needed.

--- a/makefile
+++ b/makefile
@@ -87,7 +87,8 @@ build/cgra_info_8x8.txt:
 	cd CGRAGenerator; export CGRA_GEN_USE_MEM=1; ./bin/generate.csh || exit -1
 	cp CGRAGenerator/hardware/generator_z/top/cgra_info.txt build/cgra_info_8x8.txt
 
-build/%_pnr_bitstream: build/%_mapped.json build/cgra_info_4x4.txt
+# build/%_pnr_bitstream: build/%_mapped.json build/cgra_info_4x4.txt
+build/%_pnr_bitstream: build/%_mapped.json build/cgra_info_$(CGRA_SIZE).txt
         # 
         # pnr
         # IN:  mapped.json      # Output from mapper
@@ -102,7 +103,7 @@ build/%_pnr_bitstream: build/%_mapped.json build/cgra_info_4x4.txt
 	diff CGRAGenerator/hardware/generator_z/top/cgra_info.txt build/cgra_info_4x4.txt
 
 
-	smt-pnr/src/test.py  build/$*_mapped.json CGRAGenerator/hardware/generator_z/top/cgra_info.txt --bitstream build/$*_pnr_bitstream --annotate build/$*_annotated --print  --coreir-libs stdlib cgralib
+# 	smt-pnr/src/test.py  build/$*_mapped.json CGRAGenerator/hardware/generator_z/top/cgra_info.txt --bitstream build/$*_pnr_bitstream --annotate build/$*_annotated --print  --coreir-libs stdlib cgralib
 # 	smt-pnr/src/test.py  \
 # 	  build/$*_mapped.json \
 # 	  CGRAGenerator/hardware/generator_z/top/cgra_info.txt \
@@ -110,13 +111,14 @@ build/%_pnr_bitstream: build/%_mapped.json build/cgra_info_4x4.txt
 # 	  --annotate build/$*_annotated      \
 #	  --print  --coreir-libs stdlib cgralib
 
-        # $(filter %.txt,  $?) => config file   e.g. "build/cgra_info_4x4.txt"
         # $(filter %.json, $?) => program graph e.g. "build/pointwise_mapped.json"
+        # $(filter %.txt,  $?) => config file   e.g. "build/cgra_info_4x4.txt"
         # (Could also maybe use $(word 1, $?) and $(word 2, $?)
+        # Note json file must come before config file on command line!!!
 	\
 	smt-pnr/src/test.py       \
 	    $(filter %.json,$?)   \
-	    $(filter %.txt ,$?)   \
+	    $(filter %.txt, $?)   \
 	    --bitstream build/$*_pnr_bitstream \
 	    --annotate build/$*_annotated \
 	    --print --coreir-libs stdlib cgralib

--- a/makefile
+++ b/makefile
@@ -66,7 +66,6 @@ build/cgra_info_8x8.txt:
 	cd CGRAGenerator; ./bin/generate.csh || exit -1
 	cp CGRAGenerator/hardware/generator_z/top/cgra_info.txt build/cgra_info_8x8.txt
 
-
 build/%_pnr_bitstream: build/%_mapped.json build/cgra_info_4x4.txt
         # 
         # pnr
@@ -78,10 +77,14 @@ build/%_pnr_bitstream: build/%_mapped.json build/cgra_info_4x4.txt
         #- cd ${TRAVIS_BUILD_DIR}/smt-pnr/src/
         # 
 # 	smt-pnr/src/test.py  build/$*_mapped.json CGRAGenerator/hardware/generator_z/top/cgra_info.txt --bitstream build/$*_pnr_bitstream --annotate build/$*_annotated --print  --coreir-libs stdlib cgralib
-	echo $(filter %.txt,$?)
+        # filter (below) auto-extracts cgra_info file from dependency list maybe
+        # I think $(word 2,$?) will return second dependence thingy
+	@echo Making $@ because of $?
+	\
 	set config=$(filter %.txt,$?); \
+	set graph=$(filter %.json,$?); \
 	smt-pnr/src/test.py  \
-	    build/$*_mapped.json \
+	    $${graph}  \
 	    $${config} \
 	    --bitstream build/$*_pnr_bitstream \
 	    --annotate build/$*_annotated \

--- a/makefile
+++ b/makefile
@@ -21,7 +21,12 @@ $(warning MEM_SWITCH = $(MEM_SWITCH))
 ########################################################################
 
 
-all: build/pointwise.correct.txt build/conv_bw_mapped.json build/cascade_mapped.json
+all: start_testing build/pointwise.correct.txt build/conv_bw_mapped.json build/cascade_mapped.json
+
+start_testing:
+	if `test -e build/test_summary.txt`; then rm build/test_summary.txt; fi
+	echo TEST SUMMARY > build/test_summary.txt
+	echo BEGIN `date` >> build/test_summary.txt
 
 build/%_design_top.json: Halide_CoreIR/apps/coreir_examples/%
 	echo "Halide FLOW"
@@ -161,7 +166,11 @@ build/%.correct.txt: build/%_CGRA_out.raw
 	@echo; echo Making $@ because of $?
 	echo "BYTE-BY-BYTE COMPARE OF CGRA VS. HALIDE OUTPUT IMAGES"
 	ls -l build/*.raw
-	cmp   build/$*_halide_out.raw  build/$*_CGRA_out.raw
+	cmp build/$*_halide_out.raw build/$*_CGRA_out.raw \
+	    && echo $* test PASSED  >> build/test_summary.txt \
+	    || echo $* test FAILED  >> build/test_summary.txt
+	cmp build/$*_halide_out.raw build/$*_CGRA_out.raw
+
 
 	echo "VISUAL COMPARE OF CGRA VS. HALIDE OUTPUT BYTES (should be null)"
 	od -t u1 -w1 -v -A none build/$*_halide_out.raw > /tmp/$*_halide_out.od

--- a/makefile
+++ b/makefile
@@ -115,8 +115,8 @@ build/%_pnr_bitstream: build/%_mapped.json build/cgra_info_4x4.txt
         # I think $(word 2,$?) will return second dependence thingy
 	@echo; echo Making $@ because of $?
 	\
-	set config=$(filter %.txt,$?); \
-	set graph=$(filter %.json,$?); \
+	config=$(filter %.txt, $?); \
+	graph=$(filter  %.json,$?); \
 	echo smt-pnr/src/test.py  \
 	    $(filter %.txt ,$?)   \
 	    $(filter %.json,$?)   \


### PR DESCRIPTION
These changes are designed to ease the transition from 4x4 to 8x8 fabric; instead of just "make" the default in this new travis script is "make CGRA_SIZE=4x4" and for the transition this will simply change to "make CGRA_SIZE=8x8" and all the right things should happen.

Also I implemented an "after-script" summary of what passed and failed, so people can just look to see that at the very end of the travis log instead of searching through to see what happened.