### PR TITLE
Directing coreir branch to master_old which is identical to master

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,7 @@ export pnr_git="https://github.com/cdonovick/smt-pnr"
 export smt_git="https://github.com/makaimann/smt-switch"
 
 export halide_branch="coreir"
-export coreir_branch="master"
+export coreir_branch="master_old"
 export mapper_branch="master"
 export cgra_branch="master"
 export pnr_branch="master"


### PR DESCRIPTION
Doing this so I can merge coreir dev into real master for the hackathon