### PR TITLE
New IO interface and SMT cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,7 @@ env:
     - CGRAFLOW_HOME=${TRAVIS_BUILD_DIR}
     - CGRAFLOW_PATH=${CGRAFLOW_HOME}
 
-cache:
-  apt: true
-  directories:
-    # cache smt solvers to speed up build
-    ./smt_solvers
+cache: pip
 
 compiler:
   - gcc

--- a/install.sh
+++ b/install.sh
@@ -62,13 +62,13 @@ python scripts/repo_manager.py                                                  
     --mapper                      master                                        \
     --mapper-remote               github.com/StanfordAHA/CGRAMapper.git         \
                                                                                 \
-    --cgra-generator              master                                        \
+    --cgra-generator              dev                                           \
     --cgra-generator-remote       github.com/StanfordAHA/CGRAGenerator.git      \
                                                                                 \
-    --test-bench-generator        master                                        \
+    --test-bench-generator        io-reset                                      \
     --test-bench-generator-remote github.com/StanfordAHA/TestBenchGenerator.git \
                                                                                 \
-    --cgra-pnr                    master                                        \
+    --cgra-pnr                    new_io                                        \
     --cgra-pnr-remote             github.com/Kuree/cgra_pnr.git                 \
 
 

--- a/install.sh
+++ b/install.sh
@@ -53,12 +53,6 @@ python scripts/repo_manager.py                                                  
     --pycoreir                    master                                        \
     --pycoreir-remote             github.com/leonardt/pycoreir.git              \
                                                                                 \
-    --pnr-doctor                  master                                        \
-    --pnr-doctor-remote           github.com/cdonovick/smt-pnr.git              \
-                                                                                \
-    --smt-switch                  master                                        \
-    --smt-switch-remote           github.com/makaimann/smt-switch.git           \
-                                                                                \
     --mapper                      master                                        \
     --mapper-remote               github.com/StanfordAHA/CGRAMapper.git         \
                                                                                 \

--- a/makefile
+++ b/makefile
@@ -346,6 +346,7 @@ else ifeq ($(PNR), cgra_pnr)
 		< build/$*_annotated.bsb            \
 		> build/$*_pnr_bitstream
 	cp build/$*_pnr_bitstream build/$*_annotated
+	cp build/$*_annotated.bsb.json build/$*_io.json
 else
 	$(error smt_pnr no longer supported)
 endif
@@ -403,7 +404,7 @@ ifeq ($(PNR), serpent)
 		-config    $(BUILD)/$*_pnr_bitstream \
 		-input     $(BUILD)/$*_input.png     \
 		-output    $(BUILD)/$*_CGRA_out.raw  \
-		-out1 s1t0 $(BUILD)/1bit_out.raw     \
+		-out1      $(BUILD)/1bit_out.raw     \
 		-delay $(DELAY) \
 		-nclocks 5M
 
@@ -417,9 +418,10 @@ ifeq ($(PNR), cgra_pnr)
 	@cd $(VERILATOR_TOP);   \
 	./run_tbg.csh $(QVSWITCH) -gen \
 		-config    $(BUILD)/$*_pnr_bitstream \
+		-io_config $(BUILD)/$*_io.json       \
 		-input     $(BUILD)/$*_input.png     \
 		-output    $(BUILD)/$*_CGRA_out.raw  \
-		-out1 s1t0 $(BUILD)/1bit_out.raw     \
+		-out1      $(BUILD)/1bit_out.raw     \
 		-delay $(DELAY) \
 		-nclocks 5M
 

--- a/makefile
+++ b/makefile
@@ -347,21 +347,7 @@ else ifeq ($(PNR), cgra_pnr)
 		> build/$*_pnr_bitstream
 	cp build/$*_pnr_bitstream build/$*_annotated
 else
-# 	smt-pnr/src/test.py  build/$*_mapped.json CGRAGenerator/hardware/generator_z/top/cgra_info.txt --bitstream build/$*_pnr_bitstream --annotate build/$*_annotated --print  --coreir-libs stdlib cgralib
-
-        # $(filter %.json, $?) => program graph e.g. "build/pointwise_mapped.json"
-        # $(filter %.txt,  $?) => config file   e.g. "build/cgra_info_4x4.txt"
-        # (Could also maybe use $(word 1, $?) and $(word 2, $?)
-        # Note json file must come before config file on command line!!!
-	smt-pnr/run_pnr.py                        \
-		$(filter %.json,$?)                   \
-		$(filter %.txt, $?)                   \
-		--bitstream build/$*_pnr_bitstream    \
-		--annotate build/$*_annotated         \
-		--io-collateral build/$*.io.json      \
-		--solver Boolector                    \
-		--debug                               \
-		--print --coreir-libs cgralib
+	$(error smt_pnr no longer supported)
 endif
 
         # Note: having the annotated bitstream embedded as cleartext in the log

--- a/scripts/repo_manager.py
+++ b/scripts/repo_manager.py
@@ -25,10 +25,6 @@ parser.add_argument("--mapper", help="mapper branch", default="master")
 parser.add_argument("--mapper-remote", help="mapper remote", default="github.com/StanfordAHA/CGRAMapper.git")
 parser.add_argument("--halide", help="halide branch", default="master")
 parser.add_argument("--halide-remote", help="halide remote", default="github.com/jeffsetter/Halide_CoreIR.git")
-parser.add_argument("--pnr-doctor", help="pnr branch", default="master")
-parser.add_argument("--pnr-doctor-remote", help="pnr remote", default="github.com/cdonovick/smt-pnr.git")
-parser.add_argument("--smt-switch", help="smt-switch branch", default="master")
-parser.add_argument("--smt-switch-remote", help="smt-switch remote", default="github.com/makaimann/smt-switch.git")
 parser.add_argument("--cgra-generator", help="generator branch", default="master")
 parser.add_argument("--cgra-generator-remote", help="generator remote", default="github.com/Kuree/cgra_pnr.git")
 parser.add_argument("--cgra-pnr", help="cgra_pnr branch", default="master")
@@ -98,22 +94,6 @@ class CGRAMapper(Repo):
         run("make clean", cwd=repo.directory)
         run("sudo make -j 2 install", cwd=repo.directory)
 
-class PnRDoctor(Repo):
-    directory = "smt-pnr"
-
-    def install(self):
-        run("pip install -e package", cwd=repo.directory)
-
-    def setup(self):
-        run("./util/get_smt_solvers.sh", cwd=repo.directory)
-        run("pip install -e smt_solvers/monosat/python", cwd=repo.directory)
-
-class smt_switch(Repo):
-    directory = "smt-switch"
-
-    def install(self):
-        run("pip install -e .", cwd=repo.directory)
-
 class CGRAGenerator(Repo):
     def install(self):
         pass
@@ -145,14 +125,6 @@ repos = (
     CGRAMapper(
         remote=args.mapper_remote,
         branch=args.mapper
-    ),
-    PnRDoctor(
-        remote=args.pnr_doctor_remote,
-        branch=args.pnr_doctor
-    ),
-    smt_switch(
-        remote=args.smt_switch_remote,
-        branch=args.smt_switch
     ),
     CGRAGenerator(
         remote=args.cgra_generator_remote,

--- a/setenv.sh
+++ b/setenv.sh
@@ -5,9 +5,6 @@ export PYTHONPATH=$PYTHONPATH:$CGRAFLOW_PATH/smt-switch
 export COREIR=$CGRAFLOW_PATH/coreir
 export LD_LIBRARY_PATH=$COREIR/lib:$LD_LIBRARY_PATH
 
-export SMT_SOLVER_PATH=$CGRAFLOW_PATH/smt-pnr/smt_solvers  # used by set_env_for_solvers.sh
-source $CGRAFLOW_PATH/smt-pnr/util/set_env_for_solvers.sh
-
 export CC=gcc-4.9
 export CXX=g++-4.9
 #export CGRA_SIZE=8x8


### PR DESCRIPTION
1. Changed `run_tbg.csh` interface because some design changes, such as taking IO json directly instead of hardcoding it in the `bsbuilder`.
2. Remove SMT-based PnR since it no longer supports the new IO interface.

**Note**:
Currently it uses dev branches in corresponding repos. I will change them back to `master` banchs once they're merged to their masters.
