### PR TITLE
Fix master branch

### DIFF
--- a/scripts/install_locally.sh
+++ b/scripts/install_locally.sh
@@ -43,7 +43,7 @@ python scripts/repo_manager.py                                                  
     --test-bench-generator        master                                        \
     --test-bench-generator-remote github.com/StanfordAHA/TestBenchGenerator.git \
                                                                                 \
-    --cgra-pnr                    dev                                           \
+    --cgra-pnr                    master                                        \
     --cgra-pnr-remote             github.com/Kuree/cgra_pnr.git                 \
 
 

--- a/scripts/install_locally.sh
+++ b/scripts/install_locally.sh
@@ -34,9 +34,6 @@ python scripts/repo_manager.py                                                  
     --coreir                      master                                        \
     --coreir-remote               github.com/rdaly525/coreir.git                \
                                                                                 \
-    --pycoreir                    master                                        \
-    --pycoreir-remote             github.com/leonardt/pycoreir.git              \
-                                                                                \
     --mapper                      master                                        \
     --mapper-remote               github.com/StanfordAHA/CGRAMapper.git         \
                                                                                 \
@@ -49,8 +46,6 @@ python scripts/repo_manager.py                                                  
     --cgra-pnr                    dev                                           \
     --cgra-pnr-remote             github.com/Kuree/cgra_pnr.git                 \
 
-
-pip install -e pycoreir
 
 # get the halide release
 cd Halide-to-Hardware

--- a/scripts/install_locally.sh
+++ b/scripts/install_locally.sh
@@ -46,7 +46,7 @@ python scripts/repo_manager.py                                                  
     --test-bench-generator        master                                        \
     --test-bench-generator-remote github.com/StanfordAHA/TestBenchGenerator.git \
                                                                                 \
-    --cgra-pnr                    master                                        \
+    --cgra-pnr                    dev                                           \
     --cgra-pnr-remote             github.com/Kuree/cgra_pnr.git                 \
 
 

--- a/scripts/repo_manager.py
+++ b/scripts/repo_manager.py
@@ -21,8 +21,6 @@ parser.add_argument("-f", "--force", action="store_true", help="Force rebuild an
 parser.add_argument("--with-ssh", action="store_true", help="Clone with ssh", default=False)
 parser.add_argument("--coreir", help="coreir branch", default="master")
 parser.add_argument("--coreir-remote", help="coreir remote ", default="github.com/rdaly525/coreir.git")
-parser.add_argument("--pycoreir", help="pycoreir branch", default="master")
-parser.add_argument("--pycoreir-remote", help="pycoreir remote ", default="github.com/leonardt/pycoreir.git")
 parser.add_argument("--mapper", help="mapper branch", default="master")
 parser.add_argument("--mapper-remote", help="mapper remote", default="github.com/StanfordAHA/CGRAMapper.git")
 parser.add_argument("--halide", help="halide branch", default="master")
@@ -90,10 +88,6 @@ class coreir(Repo):
         #run("make clean", cwd=repo.directory)
         run("cd build && cmake .. && make -j8 && cd ..", cwd=repo.directory)
 
-class pycoreir(Repo):
-    def install(self):
-        run("pip install -e .", cwd=repo.directory)
-
 class CGRAMapper(Repo):
     def install(self):
         #run("make clean", cwd=repo.directory)
@@ -137,10 +131,6 @@ repos = (
     coreir(
         remote=args.coreir_remote,
         branch=args.coreir
-    ),
-    pycoreir(
-        remote=args.pycoreir_remote,
-        branch=args.pycoreir
     ),
     CGRAMapper(
         remote=args.mapper_remote,


### PR DESCRIPTION
Remove the dependency of `pycoreir`. It's never been used in any tools (it was used in the old PnR tools).

This should also fix the error in travis.